### PR TITLE
Add examples for North America (USGS maps, Google Maps and OpenStreetMaps

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+This directory contains sample mapconfig.xml and mapconfig.js configuration for various providers
+and geographies.
+

--- a/examples/usa-usgs/mapcache.xml
+++ b/examples/usa-usgs/mapcache.xml
@@ -1,0 +1,175 @@
+ <?xml version="1.0" encoding="UTF-8"?>
+ 
+ <mapcache>
+   <!--
+   *******************************************************
+   Set up caches here. Files, sqlite, mbtiles, etc..
+   *******************************************************
+   -->
+
+   <cache name="osm_sqlite" type="sqlite3">
+    <dbfile>/var/lib/polaric/mapcache/maps_osm.db</dbfile>
+   </cache>
+
+   <cache name="usgs_topo" type="sqlite3">
+     <dbfile>/var/lib/polaric/mapcache/usgs_topo.db</dbfile>
+   </cache>
+   
+   <cache name="usgs_imagery" type="sqlite3">
+     <dbfile>/var/lib/polaric/mapcache/usgs_imagery.db</dbfile>
+   </cache>
+   
+   <!--
+   **********************************************************************
+   Set up sources here.
+   It is typically an external WMS service. Mapcache supports some
+   other source types like mapserver mapfiles.
+   **********************************************************************
+   -->
+
+  <!-- German WMS server setup for OSM data, with its own theme -->
+  <!-- http://www.osm-wms.de/ -->
+  <source name="osm_cache" type="wms">
+   <getmap>
+     <params>
+        <FORMAT>image/png</FORMAT>
+         <LAYERS>osm_auto:all</LAYERS>
+       </params>
+     </getmap>
+      <http>
+       <url>http://129.206.228.72/cached/osm?</url>
+     </http>
+   </source> 
+
+  <source name="usgs_topo_cache" type="wms">
+   <getmap>
+     <params>
+       <FORMAT>image/png</FORMAT>
+       <LAYERS>0</LAYERS>
+     </params>
+   </getmap>
+    <http>
+     <url>http://basemap.nationalmap.gov/arcgis/services/USGSTopo/MapServer/WMSServer</url>
+    </http>
+  </source>
+
+  <source name="usgs_imagery_cache" type="wms">
+   <getmap>
+     <params>
+       <FORMAT>image/png</FORMAT>
+       <LAYERS>0</LAYERS>
+     </params>
+   </getmap>
+    <http>
+     <url>http://basemap.nationalmap.gov/arcgis/services/USGSImageryOnly/MapServer/WMSServer</url>
+    </http>
+  </source>
+   
+   <!--
+   **********************************************************************
+   Set up grids here.
+   A grid defines map projection, tile size, extent and resolutions.
+   
+   Resolutions must match the resolutions for the OpenLayers client.
+   If using tiled cache services (e.g. Kartverket) as sources, we
+   must match their resolutions exactly as well
+   (see also mapconfig.js).
+   **********************************************************************
+   -->
+   <grid name="utm32">
+     <metadata>
+       <title>UTM zone 32 for Norway. Matches Kartverket cache-service.</title>
+     </metadata>
+     
+     <srs>EPSG:32632</srs>
+     <size>256 256</size>
+     <extent> -2000000,3500000,3545984,9045984 </extent>
+     <resolutions>1354.0 677.0 338.5 169.25 84.625 42.3125 21.15625 10.5781248 5.2890624 2.6445312 1.3222656 0.6611328</resolutions>
+   </grid>
+   
+   <grid name="utm33">
+     <metadata>
+       <title>UTM zone 33 for Norway.  Matches Kartverket cache-service.</title>
+     </metadata>
+     
+     <srs>EPSG:32633</srs>
+     <size>256 256</size>
+     <extent> -2500000.0,3500000.0,3045984.0,9045984.0 </extent>
+     <resolutions>1354.0 677.0 338.5 169.25 84.625 42.3125 21.15625 10.5781248 5.2890624 2.6445312 1.3222656 0.6611328</resolutions>
+   </grid>
+
+<!-- Directly from http://basemap.nationalmap.gov/arcgis/rest/services/USGSTopo/MapServer -->
+   <grid name="usgs_102100">
+     <metadata>
+       <title>USGSTopo standard grid</title>
+     </metadata>
+     <srs>EPSG:102100</srs> 
+     <size>256 256</size>
+     <extent>-2.0037507067161843E7, -3.0240971958386254E7, 2.0037507067161843E7, 3.0240971958386205E7</extent>
+     <resolutions>156543.03392800014 78271.51696399994 39135.75848200009 19567.87924099992 9783.93962049996 4891.96981024998 2445.98490512499 1222.992452562495 611.4962262813797 305.74811314055756 152.87405657041106 76.43702828507324 38.21851414253662 19.10925707126831 9.554628535634155 4.77731426794937 2.388657133974685 1.1943285668550503 0.5971642835598172 0.29858214164761665</resolutions>
+  </grid>
+   
+   <!--
+   ********************************************************************
+    Set up tilesets here.
+    A tileset defines a source, a cache, a grid and a format as well
+    as a metatile size, and expire time. auto_expire is the numbers
+    of seconds before the server cache expire and will try to reload. 
+    0 means - never expire. 
+   ********************************************************************
+   -->
+
+   <tileset name="osm_cache">
+     <source>osm_cache</source>
+     <cache>osm_sqlite</cache>
+     <format>mixed</format>
+     <grid>g</grid>
+     <metatile>1 1</metatile>
+     <metabuffer>0</metabuffer>
+     <expires>604800</expires>
+     <auto_expire>5184000</auto_expire>
+   </tileset>
+
+   <tileset name="usgs_topo_cache">
+     <source>usgs_topo_cache</source>
+     <cache>usgs_topo</cache>
+     <format>mixed</format>
+     <grid>usgs_102100</grid>
+     <metatile>1 1</metatile>
+     <metabuffer>0</metabuffer>
+     <expires>604800</expires>
+     <auto_expire>5184000</auto_expire>
+   </tileset>   
+   
+
+   <tileset name="usgs_imagery_cache">
+     <source>usgs_imagery_cache</source>
+     <cache>usgs_imagery</cache>
+     <format>mixed</format>
+     <grid>usgs_102100</grid>
+     <metatile>1 1</metatile>
+     <metabuffer>0</metabuffer>
+     <expires>604800</expires>
+     <auto_expire>5184000</auto_expire>
+   </tileset>   
+
+   
+   <default_format>JPEG</default_format>
+   
+   <service type="wms" enabled="true">
+     <full_wms>assemble</full_wms>
+     <resample_mode>bilinear</resample_mode>
+     <format>JPEG</format>
+     <maxsize>4096</maxsize>
+   </service>
+   
+   <service type="wmts" enabled="true"/>
+   <service type="tms" enabled="true"/>
+   
+   <errors>report</errors>
+   <lock_dir>/tmp</lock_dir>
+   
+ </mapcache>
+ 
+ 
+   

--- a/examples/usa-usgs/mapconfig.js
+++ b/examples/usa-usgs/mapconfig.js
@@ -1,0 +1,197 @@
+/* 
+ * Configuration file for polaric-webapp. This is actually javascript code.
+ * 
+ * Version 1.6 supports changing UTM projection for maps. 
+ * Version 1.7 support mixing maps with different projections, languages and more..
+ * 
+ * For projections, you may need to add the EPSG definition, e.g. if you 
+ * want to use UTM zone 35: 
+ *
+ * Proj4js.defs["EPSG:32635"] = "+proj=utm +zone=35 +ellps=WGS84 +datum=WGS84 +units=m +no_defs";*
+ *
+ * If you change projection/zone you may need to update max_extent and you 
+ * may need to update layers and mapcache.xml as well. 
+ *
+ */
+
+/*
+ * Language for user interface: Supported languages are: 
+ *  'no' = Norwegian
+ *   Default is English (just comment out the next line)
+ * 
+ * It is also possible so change the language by using the 
+ * URL parameter 'lang'
+ */
+//LANGUAGE('no');
+
+
+/*
+ * Base URL of server. Leave it empty if the server
+ * and the js document are at the same location. 
+ */ 
+var server_url = '';
+
+
+
+/* 
+ * Default system projection. Currently we assume that this 
+ * is a UTM projection. It has to be known by Proj4js
+ */
+var utm_projection = "EPSG:900913";
+
+/*
+ * Default map extents. Resolutions and number of zoom levels.
+ * Can (probably) be overridden by the individual base layers.  
+ */ 
+var max_extent = [-2.0037507067161843E7, -3.0240971958386254E7, 2.0037507067161843E7, 3.0240971958386205E7];
+var max_resolution = 156543.0339280410;
+var min_resolution = 0.5971642834779395;
+var max_zoomlevels = 19; 
+
+
+
+var default_attribution = 'Map: <a href="http://basemap.nationalmap.gov/">USGS National Map</a>, <a href="http://www.openstreetmap.org/">OpenStreetMap</a>';
+
+
+/*
+ * Bacground color for maps
+ */
+var backgroundColor = '#A1C1C9';
+
+
+/*
+ * List of base layers. This is a fairly straightforward OpenLayers way
+ * of setting up layers. Use the LAYER function to add a set of layers. This 
+ * can be used more than once. 
+ * 
+ * The LAYERS function takes three arguments: 
+ *    - if this is a base layer (boolean)
+ *    - A predicate (a function returning a boolean value). This acts as a filter. 
+ *      if evaluated to true the layers are shown in layer list. The predefined TRUE 
+ *      always evaluates to true.
+ *    - An array of layers. See OpenLayers documentation. 
+ *
+ * To add GPX vector layers, put the gpx files in directory /gpx and
+ * use the function add_Gpx_Layer(name, file) to add them to the list like 
+ * in the example below. 
+ */
+
+
+/* Polygon that draws a border around Norway */
+var Norge = POLYGON( [
+    {lat:58.979, lng:11.557}, {lat:58.692, lng:9.725},  {lat:57.819, lng:7.408},  {lat:58.911, lng:4.911}, 
+    {lat:62.343, lng:4.428},  {lat:64.567, lng:9.962},  {lat:67.99,  lng:11.675}, {lat:70.029, lng:16.842}, 
+    {lat:71.528, lng:26.154}, {lat:70.39,  lng:31.944}, {lat:69.19,  lng:29.1},   {lat:70.05,  lng:27.899}, 
+    {lat:68.481, lng:24.854}, {lat:68.979, lng:21.04},  {lat:68.306, lng:20.021}, {lat:68.349, lng:18.581}, 
+    {lat:64.618, lng:13.877}, {lat:64.414, lng:14.363}, {lat:63.957, lng:14.014}, {lat:63.963, lng:12.853},
+    {lat:61.782, lng:12.287}, {lat:61.244, lng:12.971} 
+]);
+
+
+/* OpenStreetMap base layer */
+LAYERS (true, TRUE, [
+     new OpenLayers.Layer.OSM("OpenStreetMap", null, {gray: '0.1'})
+]);
+
+/* Google Maps base layers.
+   Note: requires switching the layer a couple of times to work? Don't know where
+         the issue comes from, since no error is generated?
+ */
+LAYERS (true, TRUE, [
+     new OpenLayers.Layer.Google("Google Satellite", {type: google.maps.MapTypeId.SATELLITE}),
+    new OpenLayers.Layer.Google("Google Terrain", {type: google.maps.MapTypeId.TERRAIN}),
+     new OpenLayers.Layer.Google("Google Streets")
+ ]);
+
+
+/* Cached Topographic and imagery maps from the USGS. Detailed map for USA, and
+   basemap for the rest of the world. Requires a working mapcache installation
+   */
+LAYERS (true, TRUE, [
+     new OpenLayers.Layer.TMS(
+      "USGS Topo (cache)", "/mapcache/tms",
+      { layername: 'usgs_topo_cache', type: 'png' }
+     ),
+      new OpenLayers.Layer.TMS(
+      "USGS Imagery (cache)", "/mapcache/tms",
+      { layername: 'usgs_imagery_cache', type: 'jpg' }
+     )
+]);
+
+
+/* Overlay layer. UTM/MGRS Grid (from Kartverket WMS) */
+LAYERS (false, TRUE, [  
+       new OpenLayers.Layer.WMS(
+         "UTM/MGRS Grids", "http://openwms.statkart.no/skwms1/wms.rutenett",
+         { layers:'UTMrutenett',transparent: true },
+         { isBaseLayer: false, singleTile: true, ratio: 1, visibility: false }
+       )
+ ]);
+
+
+
+
+
+
+/*
+ * Menu of predefined map-extents.  
+ * Extents are upper left corner (1) and lower right corner (2) in decimal degrees
+ * [longitude-1, latitude-1, longitude-2, latitude-2] 
+ */
+var defaultView = 'bayarea';
+var mapViews = [
+  { name: 'ca',      title:'California',  extent: [-136.1, 43.2, -105.5, 30.5]},
+  { name: 'bayarea', title:'SF Bay Area', extent: [ -123.54, 38.17, -119.58, 36.9] },
+  { name: 'tahoe',   title:'Lake Tahoe',  extent: [ -121, 39.5, -118.8, 38.5  ]},
+  { name: 'usa',     title: 'USA',        extent: [-127.4, 49.5, -64.5, 24]}
+];
+
+
+/* Filter menu. The actual filters are defined by aprsd in
+ * /etc/polaric-aprsd/view.profiles. The name attribute refers to a profile-name. 
+ * For non-public profiles, add attribute: restricted: 'true' 
+ */
+
+var filterViews = [
+   { name: 'alle',   title: 'Everything' },
+   { name: 'track',  title: 'Track 1' },
+   { name: 'infra',  title: 'Infrastructure'},
+   { name: 'ainfra', title: 'Active infrastructure'},
+   { name: 'moving', title: 'Moving objects'}
+];
+
+/* View to be selected by default */
+var defaultFilterView = 'alle';
+
+
+/* Set to true to enable SAR URL */
+var sarUrl = false; 
+
+
+/* Use WPS service from Statkart to get elevation data, 
+ * for now, you have to set up a proxy for this on the server
+ * with the same domain name as your service. It is VERY important 
+ * to remove all Authorization headers from proxied requests, to 
+ * avoid leaking authentication info. 
+ */
+
+var statkartWPS_enable = false;
+var statkartWPS_url = "/aprs/wps";
+
+
+var statkartName_enable = false; 
+var statkartName_url = "/namesearch";
+
+
+
+/* Use service from met.no go get weather forecasts.
+ * For now, you have to set up a proxy for this on the server
+ * with the same domain name as your service. It is VERY important 
+ * to remove all Authorization headers from proxied requests, to 
+ * avoid leaking authentication info. 
+ * 
+ * To activate this, you should know what you are doing!
+ */
+
+var WXreport_enable = false;
+var WXreport_url = "/aprs/wxdata";


### PR DESCRIPTION
This is a simple mapcache/mapconfig configuration set which works great for North America, using the USGS "NationalMap" service.

Requires a working mapcache on the local instance, so that the topographic and imagery tiles can be cached and served by the Polaric Server.